### PR TITLE
[hsa-3789] use unicode scalars when trimming EPUB, check for element in dom

### DIFF
--- a/Sources/Navigator/EPUB/Assets/Static/scripts/readium-reflowable.js
+++ b/Sources/Navigator/EPUB/Assets/Static/scripts/readium-reflowable.js
@@ -4955,6 +4955,7 @@ function selectionText(totalText) {
 // Public API used by the navigator.
 window.readium = {
   // utils
+  doesElementExist: _utils__WEBPACK_IMPORTED_MODULE_1__.doesElementExist,
   scrollToId: _utils__WEBPACK_IMPORTED_MODULE_1__.scrollToId,
   scrollToPosition: _utils__WEBPACK_IMPORTED_MODULE_1__.scrollToPosition,
   scrollToText: _utils__WEBPACK_IMPORTED_MODULE_1__.scrollToText,
@@ -5576,6 +5577,7 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   "getColumnCountPerScreen": () => (/* binding */ getColumnCountPerScreen),
 /* harmony export */   "isScrollModeEnabled": () => (/* binding */ isScrollModeEnabled),
+/* harmony export */   "doesElementExist": () => (/* binding */ doesElementExist),
 /* harmony export */   "scrollToId": () => (/* binding */ scrollToId),
 /* harmony export */   "scrollToPosition": () => (/* binding */ scrollToPosition),
 /* harmony export */   "scrollToText": () => (/* binding */ scrollToText),
@@ -5813,6 +5815,11 @@ function scrollToRect(rect, verticallyCenter, offset) {
       rect.left + window.scrollX
     );
   }
+}
+    
+function doesElementExist(id) {
+  var element = document.getElementById(id)
+  return element != undefined
 }
 
 // Returns false if the page is already at the left-most scroll offset.

--- a/Sources/Streamer/Parser/EPUB/Resource Transformers/EPUBTrimmer.swift
+++ b/Sources/Streamer/Parser/EPUB/Resource Transformers/EPUBTrimmer.swift
@@ -80,7 +80,7 @@ public func findEndTagFromEndString(within content: String, tag: String, endStri
     let matches = matches(for: endTag, in: content)
     if matches.count - 1 - position >= 0 && position >= 0 {
         let match = matches[matches.count - position - 1]
-        endString = String(content[content.index(content.startIndex, offsetBy: match.lowerBound)..<content.endIndex])
+        endString = String(content.unicodeScalars[content.unicodeScalars.index(content.unicodeScalars.startIndex, offsetBy: match.lowerBound)..<content.unicodeScalars.endIndex])
     } else {
         endString = ("</\(tag)>\n") + endString
     }


### PR DESCRIPTION
This PR addresses [HSA-3789](https://honored.atlassian.net/browse/HSA-3789), which had to do with an internal link leading to a crash when trimming the EPUB. 

Diagnosing the bug, I found that in a place where we use regex, the regex match range was outside of the bounds of the string. Pretty strange. It looks like regex under the hood uses unicode scalars, and we were only dealing with the raw strings when trying to access the match within that string.

However, that's separate from another problem, which is that the link is an internal link that shouldn't prompt opening up a new EPUB viewer. The problem here is that the link is to an element with an ID, but we have no way of being certain if that element is within the trim of the EPUB or not, since it's not a part of the included chapters.

The fix here is to check in the current document if the element exists in the DOM. If it does, we know we can internally scroll to that EPUB. Otherwise, we check against the trimmed table of contents to see if anything matches, and if it does we can safely do the same. If neither of those pass, we open up a new EPUB and push it onto the stack. 

To test this PR:

- [ ] Checkout this branch in the HonorEd package dependencies, run PROD. login to calvin@honor.education / Honor@123.Go to the course in the screenshot, go to the EPUB. Tap on the link for Exhibit 9.1. Should take you directly to the figure 9.1.

Screenshot:

https://github.com/user-attachments/assets/f650c035-2e82-4677-9054-f7c23ea662c9





[HSA-3789]: https://honored.atlassian.net/browse/HSA-3789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ