### PR TITLE
Readium: Don't show selection menu

### DIFF
--- a/Sources/Navigator/EPUB/Assets/Static/scripts/readium-reflowable.js
+++ b/Sources/Navigator/EPUB/Assets/Static/scripts/readium-reflowable.js
@@ -3666,8 +3666,6 @@ function registerTemplates(newStyles) {
     }
   }
 
-  stylesheet += "* { -webkit-touch-callout: none; } \n";
-
   if (stylesheet) {
     let styleElement = document.createElement("style");
     styleElement.innerHTML = stylesheet;
@@ -4072,9 +4070,6 @@ window.addEventListener("DOMContentLoaded", function () {
   document.body.style.cursor = "pointer";
 
   document.addEventListener("click", onClick, false);
-  document.addEventListener("contextmenu", function(event) {
-    event.preventDefault();
-  }, true);
 });
 
 function onClick(event) {

--- a/Sources/Navigator/EPUB/Assets/Static/scripts/readium-reflowable.js
+++ b/Sources/Navigator/EPUB/Assets/Static/scripts/readium-reflowable.js
@@ -3666,6 +3666,8 @@ function registerTemplates(newStyles) {
     }
   }
 
+  stylesheet += "* { -webkit-touch-callout: none; } \n";
+
   if (stylesheet) {
     let styleElement = document.createElement("style");
     styleElement.innerHTML = stylesheet;

--- a/Sources/Navigator/EPUB/Assets/Static/scripts/readium-reflowable.js
+++ b/Sources/Navigator/EPUB/Assets/Static/scripts/readium-reflowable.js
@@ -4070,6 +4070,9 @@ window.addEventListener("DOMContentLoaded", function () {
   document.body.style.cursor = "pointer";
 
   document.addEventListener("click", onClick, false);
+  document.addEventListener("contextmenu", function(event) {
+    event.preventDefault();
+  }, true);
 });
 
 function onClick(event) {

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
@@ -92,7 +92,7 @@ open class EPUBNavigatorViewController: UIViewController, VisualNavigator, Selec
         public var trimmedToc: [Link]?
         
         ///  Show selection menu
-        public var showMenu: Bool = true
+        public var showMenu: Bool
         
         public init(
             userSettings: UserSettings = UserSettings(),
@@ -104,7 +104,8 @@ open class EPUBNavigatorViewController: UIViewController, VisualNavigator, Selec
             preloadPreviousPositionCount: Int = 2,
             preloadNextPositionCount: Int = 6,
             decorationTemplates: [Decoration.Style.Id: HTMLDecorationTemplate] = HTMLDecorationTemplate.defaultTemplates(),
-            debugState: Bool = false
+            debugState: Bool = false,
+            showMenu: Bool = true
         ) {
             self.userSettings = userSettings
             self.editingActions = editingActions
@@ -113,6 +114,7 @@ open class EPUBNavigatorViewController: UIViewController, VisualNavigator, Selec
             self.preloadNextPositionCount = preloadNextPositionCount
             self.decorationTemplates = decorationTemplates
             self.debugState = debugState
+            self.showMenu = showMenu
         }
     }
 

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
@@ -91,6 +91,9 @@ open class EPUBNavigatorViewController: UIViewController, VisualNavigator, Selec
         
         public var trimmedToc: [Link]?
         
+        ///  Show selection menu
+        public var showMenu: Bool = true
+        
         public init(
             userSettings: UserSettings = UserSettings(),
             editingActions: [EditingAction] = EditingAction.defaultActions,
@@ -267,7 +270,7 @@ open class EPUBNavigatorViewController: UIViewController, VisualNavigator, Selec
         
         self.publication = publication
         self.initialLocation = initialLocation
-        self.editingActions = EditingActionsController(actions: config.editingActions, rights: publication.rights)
+        self.editingActions = EditingActionsController(actions: config.editingActions, rights: publication.rights, showMenu: config.showMenu)
         self.readingProgression = publication.metadata.effectiveReadingProgression
         self.config = config
         self.userSettings = config.userSettings

--- a/Sources/Navigator/EditingAction.swift
+++ b/Sources/Navigator/EditingAction.swift
@@ -88,7 +88,7 @@ final class EditingActionsController {
     private let actions: [EditingAction]
     private let rights: UserRights
     private var isEnabled = true
-    private var showMenu
+    private var showMenu: Bool
 
     init(actions: [EditingAction], rights: UserRights, showMenu: Bool = true) {
         self.actions = actions

--- a/Sources/Navigator/EditingAction.swift
+++ b/Sources/Navigator/EditingAction.swift
@@ -111,6 +111,7 @@ final class EditingActionsController {
     func canPerformAction(_ selector: Selector) -> Bool {
         guard
             isEnabled,
+            showMenu,
             let selection = selection,
             let action = actions.first(where: { $0.action == selector })
         else {

--- a/Sources/Navigator/EditingAction.swift
+++ b/Sources/Navigator/EditingAction.swift
@@ -88,9 +88,9 @@ final class EditingActionsController {
     private let actions: [EditingAction]
     private let rights: UserRights
     private var isEnabled = true
-    private var showMenu = true
+    private var showMenu
 
-    init(actions: [EditingAction], rights: UserRights, showMenu = true) {
+    init(actions: [EditingAction], rights: UserRights, showMenu: Bool = true) {
         self.actions = actions
         self.rights = rights
         self.showMenu = showMenu

--- a/Sources/Navigator/EditingAction.swift
+++ b/Sources/Navigator/EditingAction.swift
@@ -88,10 +88,12 @@ final class EditingActionsController {
     private let actions: [EditingAction]
     private let rights: UserRights
     private var isEnabled = true
+    private var showMenu = true
 
-    init(actions: [EditingAction], rights: UserRights) {
+    init(actions: [EditingAction], rights: UserRights, showMenu = true) {
         self.actions = actions
         self.rights = rights
+        self.showMenu = showMenu
     }
 
     /// Current user selection contents and frame in the publication view.
@@ -124,7 +126,7 @@ final class EditingActionsController {
 
     func updateSharedMenuController() {
         var items: [UIMenuItem] = []
-        if isEnabled, let selection = selection {
+        if isEnabled, showMenu, let selection = selection {
             items = actions
                 .filter { delegate?.editingActions(self, canPerformAction: $0, for: selection) ?? true }
                 .compactMap { $0.menuItem }

--- a/Sources/Navigator/Toolkit/WebView.swift
+++ b/Sources/Navigator/Toolkit/WebView.swift
@@ -35,7 +35,8 @@ final class WebView: WKWebView {
     }
     
     override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
-        return false // Disables all menu actions
+        return super.canPerformAction(action, withSender: sender)
+            && editingActions.canPerformAction(action)
     }
     
     override func copy(_ sender: Any?) {

--- a/Sources/Navigator/Toolkit/WebView.swift
+++ b/Sources/Navigator/Toolkit/WebView.swift
@@ -33,10 +33,9 @@ final class WebView: WKWebView {
         isUserInteractionEnabled = false
         isUserInteractionEnabled = true
     }
-
+    
     override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
-        return super.canPerformAction(action, withSender: sender)
-            && editingActions.canPerformAction(action)
+        return false // Disables all menu actions
     }
     
     override func copy(_ sender: Any?) {


### PR DESCRIPTION
This is needed to not show the selection menu with options like Copy, Translate, Share, etc when selecting content on the ePub for the new Reaction Flow