### PR TITLE
[HSA-3913] Fixing to add Xcode 16 support

### DIFF
--- a/Sources/LCP/Persistence/Connection.swift
+++ b/Sources/LCP/Persistence/Connection.swift
@@ -17,7 +17,7 @@ extension Connection {
     /// FIXME: Used to fix a crash with SQLite.swift pre Xcode 10.2.1.
     /// We can't use the version 0.11.6 before Xcode 10.2, but the version 0.11.5 crashes on Xcode 10.2 (ie. https://github.com/stephencelis/SQLite.swift/issues/888)
     func count(_ expressible: Expressible) throws -> Int64 {
-        let sql = "SELECT COUNT(*) FROM (\(expressible.asSQL())) AS countable;"
+        let sql = "SELECT COUNT(*) FROM (\(expressible)) AS countable;"
         return (try scalar(sql) as? Int64) ?? 0
     }
     

--- a/Sources/LCP/Persistence/Licenses.swift
+++ b/Sources/LCP/Persistence/Licenses.swift
@@ -12,16 +12,17 @@
 import Foundation
 import SQLite
 
+
 /// Database's Licenses table, in charge of keeping tracks of the
 /// licenses attributed to each books and the associated rights.
 class Licenses {
     /// Table.
     let licenses = Table("Licenses")
     /// Fields.
-    let id = Expression<String>("id")
-    let printsLeft = Expression<Int?>("printsLeft")
-    let copiesLeft = Expression<Int?>("copiesLeft")
-    let registered = Expression<Bool>("registered")
+    let id = SQLite.Expression<String>("id")
+    let printsLeft = SQLite.Expression<Int?>("printsLeft")
+    let copiesLeft = SQLite.Expression<Int?>("copiesLeft")
+    let registered = SQLite.Expression<Bool>("registered")
     
     init(_ connection: Connection) {
         
@@ -47,7 +48,7 @@ class Licenses {
         return ((try? db.count(filterLicense)) ?? 0) != 0
     }
     
-    private func get(_ column: Expression<Int?>, for licenseId: String) throws -> Int? {
+    private func get(_ column: SQLite.Expression<Int?>, for licenseId: String) throws -> Int? {
         let db = Database.shared.connection
         let query = licenses.select(column).filter(id == licenseId)
         for row in try db.prepare(query) {
@@ -56,7 +57,7 @@ class Licenses {
         return nil
     }
     
-    private func set(_ column: Expression<Int?>, to value: Int, for licenseId: String) throws {
+    private func set(_ column: SQLite.Expression<Int?>, to value: Int, for licenseId: String) throws {
         let db = Database.shared.connection
         let filterLicense = licenses.filter(id == licenseId)
         try db.run(filterLicense.update(column <- value))

--- a/Sources/LCP/Persistence/Transactions.swift
+++ b/Sources/LCP/Persistence/Transactions.swift
@@ -19,10 +19,10 @@ class Transactions: Loggable {
     /// Table.
     let transactions = Table("Transactions")
     /// Fields.
-    let licenseId = Expression<String>("licenseId")
-    let origin = Expression<String>("origin")
-    let userId = Expression<String?>("userId")
-    let passphrase = Expression<String>("passphrase") // hashed.
+    let licenseId = SQLite.Expression<String>("licenseId")
+    let origin = SQLite.Expression<String>("origin")
+    let userId = SQLite.Expression<String?>("userId")
+    let passphrase = SQLite.Expression<String>("passphrase") // hashed.
     
     init(_ connection: Connection)  {
         do {


### PR DESCRIPTION
We need these changes as the version of Swift coming with Xcode brings Expression Framework, which name collides with a name used by SQLite framework

Fixes: https://honored.atlassian.net/browse/HSA-3913