### PR TITLE
[HSA-3952] reset decorations when document position changes

### DIFF
--- a/Sources/Navigator/EPUB/Assets/Static/scripts/readium-reflowable.js
+++ b/Sources/Navigator/EPUB/Assets/Static/scripts/readium-reflowable.js
@@ -4042,6 +4042,12 @@ window.addEventListener(
   },
   false
 );
+    
+window.addEventListener('resize', function() {
+    groups.forEach(function (group) {
+      group.requestLayout();
+    });
+})
 
 
 /***/ }),


### PR DESCRIPTION
Because of some changes we made to incorporate landscape (while preventing reflow), we started mutating the width of the body of each document. That worked fine for transitioning between portrait and landscape, but when you show a sheet and then dismiss it, commentary icons linger because the decorations are not getting redrawn. There's a resize observer above the diff below, but it doesn't fire when dismissing the sheet because the document's body doesn't change the size. So, the position of the decoration remains unchanged despite the horizontal position of the body changing.

The fix here was to run similar code when the size of the window changes (since this is no longer 1:1 with changes to the body's size).